### PR TITLE
Allow disabling the volumeClaimTemplate

### DIFF
--- a/charts/dremio_v2/templates/dremio-coordinator.yaml
+++ b/charts/dremio_v2/templates/dremio-coordinator.yaml
@@ -36,6 +36,8 @@ spec:
             cpu: {{ $.Values.coordinator.cpu }}
             memory: {{ $.Values.coordinator.memory }}Mi
         volumeMounts:
+        - name: dremio-master-volume
+          mountPath: /opt/dremio/data
         - name: dremio-config
           mountPath: /opt/dremio/conf
         - name: dremio-hive2-config

--- a/charts/dremio_v2/templates/dremio-master.yaml
+++ b/charts/dremio_v2/templates/dremio-master.yaml
@@ -228,6 +228,7 @@ spec:
       {{- include "dremio.coordinator.extraVolumes" $ | nindent 6 }}
       {{- include "dremio.distStorage.nas.volume" $ | nindent 6 }}
       {{- include "dremio.imagePullSecrets" $ | nindent 6 }}
+  {{- if $.Values.coordinator.volumeClaimEnabled }}
   volumeClaimTemplates:
   - metadata:
       name: dremio-master-volume
@@ -237,4 +238,5 @@ spec:
       resources:
         requests:
           storage: {{ $.Values.coordinator.volumeSize }}
+  {{- end -}}
 {{- end -}}

--- a/charts/dremio_v2/values.yaml
+++ b/charts/dremio_v2/values.yaml
@@ -45,6 +45,8 @@ coordinator:
   # The total number of coordinators will always be count + 1.
   count: 0
 
+  volumeClaimEnabled: true
+
   # Coordinator data volume size (applies to the master coordinator only).
   # In most managed Kubernetes environments (AKS, GKE, etc.), the size of the disk has a direct impact on
   # the provisioned and maximum performance of the disk.


### PR DESCRIPTION
In order to enable the HA coordinators, we need to share the coordinator disk over NFS - but by default the Helm chart hard-codes it to be a volume claim template for the main coordinator.

Allow disabling this and then we can use the `extraVolumes` config to mount in the NFS volume.