### PR TITLE
Bump the Dremio coordinator startup probe to 2h

### DIFF
--- a/charts/dremio_v2/templates/dremio-master.yaml
+++ b/charts/dremio_v2/templates/dremio-master.yaml
@@ -103,8 +103,8 @@ spec:
             scheme: HTTPS
             {{- end }}
             port: web
-          failureThreshold: 10
-          periodSeconds: 5
+          failureThreshold: 60
+          periodSeconds: 120
         readinessProbe:
           httpGet:
             path: /


### PR DESCRIPTION
Dremio changed their chart to add a startup probe, but only gave it 50 seconds - which is too short for our Dremio cluster. I bumped it to 2h.