### PR TITLE
Remove the master volumeMount for dremio-coordinator

### DIFF
--- a/charts/dremio_v2/templates/dremio-coordinator.yaml
+++ b/charts/dremio_v2/templates/dremio-coordinator.yaml
@@ -36,8 +36,6 @@ spec:
             cpu: {{ $.Values.coordinator.cpu }}
             memory: {{ $.Values.coordinator.memory }}Mi
         volumeMounts:
-        - name: dremio-master-volume
-          mountPath: /opt/dremio/data
         - name: dremio-config
           mountPath: /opt/dremio/conf
         - name: dremio-hive2-config


### PR DESCRIPTION
This isn't required as the secondary coordinator does not act as an HA failover.