### PR TITLE
Add helper for extra volumes to admin pod

### DIFF
--- a/charts/dremio_v2/templates/_helpers_general.tpl
+++ b/charts/dremio_v2/templates/_helpers_general.tpl
@@ -86,6 +86,26 @@ tolerations:
 {{- end -}}
 
 {{/*
+Admin - Pod Extra Volumes
+*/}}
+{{- define "dremio.admin.extraVolumes" -}}
+{{- $adminExtraVolumes := coalesce $.Values.admin.extraVolumes $.Values.extraVolumes -}}
+{{- if $adminExtraVolumes -}}
+{{ toYaml $adminExtraVolumes }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Admin - Pod Extra Volume Mounts
+*/}}
+{{- define "dremio.admin.extraVolumeMounts" -}}
+{{- $adminExtraVolumeMounts := default (default (dict) $.Values.extraVolumeMounts) $.Values.admin.extraVolumeMounts -}}
+{{- if $adminExtraVolumeMounts -}}
+{{ toYaml $adminExtraVolumeMounts }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 NAS Distributed Storage Volume
 */}}
 {{- define "dremio.distStorage.nas.volume" -}}

--- a/charts/dremio_v2/templates/dremio-admin.yaml
+++ b/charts/dremio_v2/templates/dremio-admin.yaml
@@ -28,6 +28,7 @@ spec:
       mountPath: /opt/dremio/data
     - name: dremio-config
       mountPath: /opt/dremio/conf
+    {{- include "dremio.admin.extraVolumeMounts" $ | nindent 4 }}
     command: ["sleep", "infinity"]
   {{- include "dremio.imagePullSecrets" $ | nindent 2 }}
   {{- include "dremio.admin.nodeSelector" $ | nindent 2 }}
@@ -39,4 +40,5 @@ spec:
   - name: dremio-config
     configMap:
       name: dremio-config
+  {{- include "dremio.admin.extraVolumes" $ | nindent 2 }}
 {{- end -}}


### PR DESCRIPTION
Allows us to specify if we need an extra volume (i.e. backup) to be mounted with the admin pod