### PR TITLE
Increase ZooKeeper readiness/liveness probes

### DIFF
--- a/charts/dremio_v2/templates/zookeeper.yaml
+++ b/charts/dremio_v2/templates/zookeeper.yaml
@@ -124,12 +124,15 @@ spec:
           exec:
             command: ["/bin/bash", "-c", "[ \"$(echo ruok | nc 127.0.0.1 2181)\" == \"imok\" ]" ]
           initialDelaySeconds: 10
-          timeoutSeconds: 5
+          periodSeconds: 15
+          timeoutSeconds: 15
         livenessProbe:
           exec:
             command: ["/bin/bash", "-c", "[ \"$(echo ruok | nc 127.0.0.1 2181)\" == \"imok\" ]" ]
           initialDelaySeconds: 10
-          timeoutSeconds: 5
+          periodSeconds: 15
+          timeoutSeconds: 15
+          failureThreshold: 2
         volumeMounts:
         - name: datadir
           mountPath: /data


### PR DESCRIPTION
Bump ZooKeeper liveness probe to 30 seconds to handle spikes in GC